### PR TITLE
Also try to untar the uncompressed version of the archive

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -
 mkdir -p Contents/Resources/IPMIView/Contents/Home/bin
-tar -zxvf ~/Downloads/IPMIView*.tar.gz --strip=1 -C ./Contents/Resources/IPMIView/.
+tar -zxvf ~/Downloads/IPMIView*.tar.gz --strip=1 -C ./Contents/Resources/IPMIView/. ||
+  tar -xvf ~/Downloads/IPMIView*.tar --strip=1 -C ./Contents/Resources/IPMIView/. ||
+  { echo "Something went wrong, check download of IPMIView archive" && exit 1; }
 ln -s /usr/bin/java Contents/Resources/IPMIView/Contents/Home/bin/java
 cd ..
 rsync -arv --exclude=.git --exclude=Contents/Resources/IPMIView/jre IPMIView.app ~/Applications


### PR DESCRIPTION
Sometimes the download ist automatically decompressed. In this case the script should try to untar the plain tar archive or else exit with an error.