### PR TITLE
Tolerate whitespace in the path

### DIFF
--- a/Contents/MacOS/IPMIView
+++ b/Contents/MacOS/IPMIView
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd ${DIR}/../Resources/IPMIView
+cd "${DIR}/../Resources/IPMIView"
 java -jar IPMIView20.jar


### PR DESCRIPTION
Handle whitespace in the path, for cases when the app is stored in .e.g. `~/Library/Mobile Documents/com~apple~CloudDocs/Applications/IPMIView.app`