### PR TITLE
Pull out the correct sha 256 sum

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -20,7 +20,7 @@ if which wget >/dev/null; then
   rm "${LOCAL_DOWNLOAD_LOCATION}/"robots.txt*
 
   # Check SHA-256
-  EXPECTED_SHA256=$(\grep SHA-256 "${LOCAL_DOWNLOAD_LOCATION}/CheckSum.txt" | cut -d':' -f2 | tr -d "[:space:]" | tr '[:upper:]' '[:lower:]')
+  EXPECTED_SHA256=$(\tail -1 "${LOCAL_DOWNLOAD_LOCATION}/CheckSum.txt" | cut -d':' -f2 | tr -d "[:space:]" | tr '[:upper:]' '[:lower:]')
   ACTUAL_SHA256=$(shasum -a 256 "${LOCAL_DOWNLOAD_LOCATION}"/IPMIView*.tar* | cut -d' ' -f1 | tr -d "[:space:]" | tr '[:upper:]' '[:lower:]')
   if ! diff <(echo "${EXPECTED_SHA256}") <(echo "${ACTUAL_SHA256}"); then
     echo "SHA-256 is not as expected; download corrupted."


### PR DESCRIPTION
The script was pulling out the wrong SHA256 sum from the Checksum file causing the install to bail.