### PR TITLE
Allow build to specify and use custom JAVA_HOME

### DIFF
--- a/Contents/MacOS/IPMIView
+++ b/Contents/MacOS/IPMIView
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "${DIR}/../Resources/IPMIView"
-java -jar IPMIView20.jar
+"${DIR}/../Resources/IPMIView/Contents/Home/bin/java" -jar IPMIView20.jar

--- a/script.sh
+++ b/script.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -
+if [ "" = "${JAVA_HOME}" ] ; then
+  JAVA_HOME=/usr
+fi
 
 BASE_URL="https://www.supermicro.com/en/support/resources"
 INFO_URL="${BASE_URL}/downloadcenter/smsdownload\?category\=IPMI"
@@ -84,7 +87,7 @@ tar -zxf "${LOCAL_DOWNLOAD_LOCATION}"/IPMIView*.tar* --strip=1 -C ./Contents/Res
   { echo "Something went wrong, check download of IPMIView archive" && exit 1; }
 
 echo "Linking 'java' and 'jre'..."
-ln -s /usr/bin/java Contents/Resources/IPMIView/Contents/Home/bin/java
+ln -s "${JAVA_HOME}/bin/java" Contents/Resources/IPMIView/Contents/Home/bin/java
 rm -rf Contents/Resources/IPMIView/jre/*
 pushd Contents/Resources/IPMIView/jre/ >/dev/null &&
   ln -s ../Contents . &&


### PR DESCRIPTION
The existing script builds an `.app` bundle which always uses the user's `PATH` to launch Java, instead of the Java that gets linked into the `.app` bundle.

This PR will use the `JAVA_HOME` environment variable which is effective at `script.sh` execution to link to the desired JVM, and will continue to use that JVM to launch IPMIView.