### PR TITLE
Documentation Changes for KVM Color Fix on X9 Boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ java -jar IPMIView20.jar
 
 If you have issues with IMPIView loading correctly with this method, please contact SuperMicro support. The problem is related to the app and your computer setup, not the wrapper.
 
-### KVM Color Issues on X9 Boards
+## KVM Color Issues on X9 Boards
 The KVM console may display incorrect colors on older X9 series boards. This is a known issue with newer versions of IPMIView [1,2,3] and looks something like this:
 
 <img width="30%" alt="Screenshot 2024-10-18 at 14 24 21" src="https://github.com/user-attachments/assets/58c6b4a3-a71b-40d4-b561-027e2c6ec33d">
@@ -69,7 +69,7 @@ The KVM console may display incorrect colors on older X9 series boards. This is 
 Perform the following steps *after IPMIView has been installed in the Applications folder*:
 1. Download `https://<BMC_IP>/libmac_x86_64__V1.0.5.jar.pack.gz` where `<BMC_IP>` should be replaced with the specific IP of your server's BMC. The exact version may depend on your BMC firmware version (e.g. V1.0.5 was found on IPMI firmware 3.36). 
 2. Unpack the downloaded file with `unpack200`, e.g. `unpack200 libmac_x86_64__V1.0.5.jar.pack.gz libmac.jar`
-3. Extract the files using `jar xf  libmac.jar` which will create 
+3. Extract the files using `jar xf libmac.jar` which will create 
 `libiKVM64.jnilib`, `libSharedLibrary64.jnilib`, and a folder called `META-INF`. The folder can be safely disregarded.
 4. Move both `jnilib` files to `Contents/Resources/IPMIView` within `IPMIView.app`, overwriting existing files. Right-click the app, and click "Show Contents" to navigate to the inner directories. This should be done to the app in `~/Applications` after already running `script.sh`.
 5. Re-launch IPMIView, open the KVM Console, and the colors should be fixed.

--- a/README.md
+++ b/README.md
@@ -58,3 +58,30 @@ java -jar IPMIView20.jar
 ```
 
 If you have issues with IMPIView loading correctly with this method, please contact SuperMicro support. The problem is related to the app and your computer setup, not the wrapper.
+
+### KVM Color Issues on X9 Boards
+The KVM console may display incorrect colors on older X9 series boards. This is a known issue with newer versions of IPMIView [1,2,3] and looks something like this:
+
+<img width="30%" alt="Screenshot 2024-10-18 at 14 24 21" src="https://github.com/user-attachments/assets/58c6b4a3-a71b-40d4-b561-027e2c6ec33d">
+
+**Note:** This fix can potentially break some features like Virtual Media or compatibility with newer boards [2,4] so it's advised to avoid doing this unless you can live without those or you're sure you don't experience those issues. 
+
+Perform the following steps *after IPMIView has been installed in the Applications folder*:
+1. Download `https://<BMC_IP>/libmac_x86_64__V1.0.5.jar.pack.gz` where `<BMC_IP>` should be replaced with the specific IP of your server's BMC. The exact version may depend on your BMC firmware version (e.g. V1.0.5 was found on IPMI firmware 3.36). 
+2. Unpack the downloaded file with `unpack200`, e.g. `unpack200 libmac_x86_64__V1.0.5.jar.pack.gz libmac.jar`
+3. Extract the files using `jar xf  libmac.jar` which will create 
+`libiKVM64.jnilib`, `libSharedLibrary64.jnilib`, and a folder called `META-INF`. The folder can be safely disregarded.
+4. Move both `jnilib` files to `Contents/Resources/IPMIView` within `IPMIView.app`, overwriting existing files. Right-click the app, and click "Show Contents" to navigate to the inner directories. This should be done to the app in `~/Applications` after already running `script.sh`.
+5. Re-launch IPMIView, open the KVM Console, and the colors should be fixed.
+
+The same boot screen after the fix: 
+
+<img width="30%" alt="Screenshot 2024-10-18 at 14 58 29" src="https://github.com/user-attachments/assets/bb62c58d-0386-4cb8-b755-e6f1c84deef1">
+
+[1] [https://forums.servethehome.com/index.php?threads/ipmi-viewer-kvm-console-color-issue.27138/](https://forums.servethehome.com/index.php?threads/ipmi-viewer-kvm-console-color-issue.27138/)
+
+[2] [https://old.reddit.com/r/simonheros/comments/mysmqe/fix_x9dr_supermicro_ipmi_colors_broken_glitched/](https://old.reddit.com/r/simonheros/comments/mysmqe/fix_x9dr_supermicro_ipmi_colors_broken_glitched/)
+
+[3] [https://www.supermicro.com/support/faqs/faq.cfm?faq=32333](https://www.supermicro.com/support/faqs/faq.cfm?faq=32333)
+
+[4] [https://tech.arantius.com/dont-fix-the-colors-in-supermicro-ipmiview](https://tech.arantius.com/dont-fix-the-colors-in-supermicro-ipmiview)


### PR DESCRIPTION
I updated the README to reflect the documentation addition suggested in #31 for fixing KVM console colors when connecting to older X9-based servers.